### PR TITLE
fix error handling for errors during queries which use `ON CLUSTER` 

### DIFF
--- a/clickhouse_connect/driver/httpclient.py
+++ b/clickhouse_connect/driver/httpclient.py
@@ -33,7 +33,7 @@ PyHttp._MAXHEADERS = 10000  # pylint: disable=protected-access
 # pylint: disable=too-many-instance-attributes
 class HttpClient(Client):
     valid_transport_settings = {'database', 'buffer_size', 'session_id', 'compress', 'decompress',
-                                'session_timeout', 'session_check', 'query_id', 'quota_key'}
+                                'session_timeout', 'session_check', 'query_id', 'quota_key', 'wait_end_of_query'}
 
     # pylint: disable=too-many-arguments,too-many-locals,too-many-branches,too-many-statements
     def __init__(self,


### PR DESCRIPTION
`SELECT name, value, changed, description, type, readonly FROM system.settings` do not return `wait_end_of_query` setting, so it added in HttpClient.valid_transport_settings

fixes error handling for errors during queries that use `ON CLUSTER` 
https://github.com/ClickHouse/ClickHouse/issues/15124